### PR TITLE
Implement simple page allocator with free

### DIFF
--- a/kernel.h
+++ b/kernel.h
@@ -2,6 +2,8 @@
 #include "common.h"
 
 paddr_t alloc_pages(uint32_t n);
+void free_pages(paddr_t paddr, uint32_t n);
+void page_alloc_init(void);
 
 // return value of sbi_call
 struct sbiret {
@@ -59,7 +61,6 @@ struct process {
 struct free_page {
   struct free_page *next;
 };
-static struct free_page *free_list = NULL;
 
 // virtual table
 #define SATP_SV32 (1u << 31)

--- a/net/virtnet.c
+++ b/net/virtnet.c
@@ -167,6 +167,8 @@ void virtio_net_transmit(void *data, uint32_t len) {
   while (vq->last_used_index == *vq->used_index)
       ;
 
+  free_pages(packet_paddr, 1);
+
   return;
 }
 


### PR DESCRIPTION
## Summary
- add free_pages() and page_alloc_init() APIs
- reuse pages using a free-list in alloc_pages()
- initialize allocator before other subsystems
- release transmit buffers in virtio_net

## Testing
- `./run.sh` *(fails: unsupported ELF machine number)*

------
https://chatgpt.com/codex/tasks/task_e_684e47defc788322930f8cd216490921